### PR TITLE
fix: pass filters to product loader

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,6 +37,8 @@ jobs:
       - name: ⬣ ESLint
         run: npm run lint
         working-directory: ./workshop
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
 
   deploy:
     name: 🚀 Deploy

--- a/exercises/03.data-fetching/01.solution.fetching-with-loaders/app/routes/_landing.products._index/route.tsx
+++ b/exercises/03.data-fetching/01.solution.fetching-with-loaders/app/routes/_landing.products._index/route.tsx
@@ -23,7 +23,7 @@ export const meta: Route.MetaFunction = ({ matches }) => {
 
 export const loader = async ({}: Route.LoaderArgs) => {
 	const [{ products }, { categories }, { brands }] = await Promise.all([
-		getProducts(),
+		getProducts({}),
 		getAllCategories(),
 		getAllBrands(),
 	])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- pass an empty filters object to `getProducts` in the first data-fetching solution
- fix the deploy workflow's TypeScript failure (`TS2554: Expected 1 arguments, but got 0`)
- raise the ESLint heap limit to prevent macOS runner out-of-memory failures

## Verification
- `npm run typecheck`
- `npm run lint`

Failing main deploy: https://github.com/epicweb-dev/react-router-fundamentals-pt-1/actions/runs/21402442815
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55ed1fca-84e2-4d71-ba1a-35dc7f73715c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55ed1fca-84e2-4d71-ba1a-35dc7f73715c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

